### PR TITLE
Add renderer module

### DIFF
--- a/lib/ratchet/renderer.ex
+++ b/lib/ratchet/renderer.ex
@@ -12,11 +12,17 @@ defmodule Ratchet.Renderer do
     |> eval(data)
   end
 
-  defp parse(template) do
+  @doc """
+  Parse template to AST
+  """
+  def parse(template) do
     Floki.parse(template)
   end
 
-  defp compile(ast) do
+  @doc """
+  Compile markup from AST
+  """
+  def compile(ast) do
     Floki.raw_html(ast)
   end
 

--- a/lib/ratchet/renderer.ex
+++ b/lib/ratchet/renderer.ex
@@ -3,6 +3,9 @@ defmodule Ratchet.Renderer do
 
   @doc """
   Render template to markup given data
+
+      iex> Renderer.render(~S{<div><p data-prop="txt"></p></div>}, %{txt: "Hi!"})
+      ~S{<div><p data-prop="txt">Hi!</p></div>}
   """
   def render(template, data) do
     template
@@ -14,6 +17,9 @@ defmodule Ratchet.Renderer do
 
   @doc """
   Parse template to AST
+
+      iex> Renderer.parse("<div></div>")
+      {"div", [], []}
   """
   def parse(template) do
     Floki.parse(template)
@@ -21,6 +27,9 @@ defmodule Ratchet.Renderer do
 
   @doc """
   Compile markup from AST
+
+      iex> Renderer.compile({"div", [], []})
+      "<div></div>"
   """
   def compile(ast) do
     Floki.raw_html(ast)

--- a/lib/ratchet/renderer.ex
+++ b/lib/ratchet/renderer.ex
@@ -1,6 +1,9 @@
 defmodule Ratchet.Renderer do
   import Ratchet.Transformer, only: [transform: 1]
 
+  @doc """
+  Render template to markup given data
+  """
   def render(template, data) do
     template
     |> parse

--- a/lib/ratchet/renderer.ex
+++ b/lib/ratchet/renderer.ex
@@ -1,0 +1,23 @@
+defmodule Ratchet.Renderer do
+  import Ratchet.Transformer, only: [transform: 1]
+
+  def render(template, data) do
+    template
+    |> parse
+    |> transform
+    |> compile
+    |> eval(data)
+  end
+
+  defp parse(template) do
+    Floki.parse(template)
+  end
+
+  defp compile(ast) do
+    Floki.raw_html(ast)
+  end
+
+  defp eval(template, data) do
+    EEx.eval_string(template, data: data)
+  end
+end

--- a/test/ratchet/renderer_test.exs
+++ b/test/ratchet/renderer_test.exs
@@ -1,0 +1,43 @@
+defmodule Ratchet.RendererTest do
+  use ExUnit.Case, async: true
+  alias Ratchet.Renderer
+  doctest Renderer
+
+  @template """
+  <section>
+    <article data-scope="posts">
+      <p data-prop="body"></p>
+      <ul>
+        <li data-prop="comments"></li>
+      </ul>
+    </article>
+  </section>
+  """
+
+  test "render/2" do
+    data = %{posts: [
+        %{body: "Thoughts and opinions.", comments: ["I disagree."]},
+        %{body: "JavaScript is dead.", comments: ["WAT", "YAY"]},
+      ]}
+
+    rendered = """
+    <section>
+      <article data-scope="posts">
+        <p data-prop="body">Thoughts and opinions.</p>
+        <ul>
+          <li data-prop="comments">I disagree.</li>
+        </ul>
+      </article>
+      <article data-scope="posts">
+        <p data-prop="body">JavaScript is dead.</p>
+        <ul>
+          <li data-prop="comments">WAT</li>
+          <li data-prop="comments">YAY</li>
+        </ul>
+      </article>
+    </section>
+    """ |> Floki.parse |> Floki.raw_html
+
+    assert Ratchet.Renderer.render(@template, data) == rendered
+  end
+end


### PR DESCRIPTION
More or less a convenience to see that ratchet can render views directly
with data. The fact that EEx is used is an implementation detail. In
practice, we'd want to use precompiled templates rather than render them
directly.
