### PR TITLE
Alternative attributes implementation

### DIFF
--- a/lib/ratchet/data.ex
+++ b/lib/ratchet/data.ex
@@ -9,4 +9,22 @@ defmodule Ratchet.Data do
   """
   def content(text) when is_binary(text), do: text
   def content({text, _attributes}), do: text
+
+  @doc """
+  Extract attributes from a data property
+
+      iex> Data.attributes({"", href: "https://google.com", rel: "nofollow"}, [])
+      ~S(href="https://google.com" rel="nofollow")
+  """
+  def attributes({_content, data_attrs}, elem_attrs) do
+    build_attrs(data_attrs ++ elem_attrs)
+  end
+
+  defp build_attrs(attributes) do
+    Enum.map_join(attributes, " ", &build_attr/1)
+  end
+
+  defp build_attr({attribute, value}) do
+    ~s(#{attribute}="#{value}")
+  end
 end

--- a/lib/ratchet/data.ex
+++ b/lib/ratchet/data.ex
@@ -15,10 +15,13 @@ defmodule Ratchet.Data do
 
       iex> Data.attributes({"", href: "https://google.com", rel: "nofollow"}, [])
       ~S(href="https://google.com" rel="nofollow")
+      iex> Data.attributes("lolwat", [{"data-prop", "joke"}])
+      ~S(data-prop="joke")
   """
   def attributes({_content, data_attrs}, elem_attrs) do
     build_attrs(data_attrs ++ elem_attrs)
   end
+  def attributes(_data, elem_attrs), do: build_attrs(elem_attrs)
 
   defp build_attrs(attributes) do
     Enum.map_join(attributes, " ", &build_attr/1)

--- a/lib/ratchet/eex.ex
+++ b/lib/ratchet/eex.ex
@@ -20,6 +20,16 @@ defmodule Ratchet.EEx do
   end
 
   @doc """
+  Build an EEx statement fetching attributes
+
+      iex> Ratchet.EEx.eex_attributes("lolwat", [])
+      "<%= Ratchet.Data.attributes(lolwat, []) %>"
+  """
+  def eex_attributes(property, attributes) do
+    "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
+  end
+
+  @doc """
   Spit out an EEx ending
   """
   def eex_close do

--- a/lib/ratchet/transformer.ex
+++ b/lib/ratchet/transformer.ex
@@ -55,6 +55,7 @@ defmodule Ratchet.Transformer do
 
   defp transform_element({:property, property}, element) do
     {element, property}
+    |> transform_attributes
     |> transform_content
     |> elem(0)
   end
@@ -70,6 +71,11 @@ defmodule Ratchet.Transformer do
 
   defp transform_content({{tag, attributes, _children}, property}) do
     children = eex_content(property) |> List.wrap
+    {{tag, attributes, children}, property}
+  end
+
+  defp transform_attributes({{tag, attributes, children}, property}) do
+    attributes = [eex_attributes(property, attributes)]
     {{tag, attributes, children}, property}
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "floki": {:hex, :floki, "0.8.0", "3ee6f8358e9f820d80f8211558458364cd137d1a7b362eb1d1989120dc288fa9", [:mix], [{:mochiweb_html, "~> 2.13", [hex: :mochiweb_html, optional: false]}]},
-  "mochiweb_html": {:hex, :mochiweb_html, "2.13.0", "795b100f757681939e2c52ab042e773af6e5602f04f4e2ea19baea832b541c08", [:rebar3], []}}
+  "floki": {:hex, :floki, "0.8.1", "06aa75bf2d1e01cda7d2ad54f68614be653a11e76b474d8fcb1d838f8c1e0ad1", [:mix], [{:mochiweb_html, "~> 2.15", [hex: :mochiweb_html, optional: false]}]},
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []}}

--- a/test/ratchet/renderer_test.exs
+++ b/test/ratchet/renderer_test.exs
@@ -7,6 +7,7 @@ defmodule Ratchet.RendererTest do
   <section>
     <article data-scope="posts">
       <p data-prop="body"></p>
+      <a data-prop="link"></a>
       <ul>
         <li data-prop="comments"></li>
       </ul>
@@ -16,20 +17,22 @@ defmodule Ratchet.RendererTest do
 
   test "render/2" do
     data = %{posts: [
-        %{body: "Thoughts and opinions.", comments: ["I disagree."]},
-        %{body: "JavaScript is dead.", comments: ["WAT", "YAY"]},
+        %{body: "Thoughts and opinions.", link: {"Google", href: "https://google.com"}, comments: ["I disagree."]},
+        %{body: "JavaScript is dead.", link: {"Iamvery", href: "https://iamvery.com"}, comments: ["WAT", "YAY"]},
       ]}
 
     rendered = """
     <section>
       <article data-scope="posts">
         <p data-prop="body">Thoughts and opinions.</p>
+        <a href="https://google.com" data-prop="link">Google</a>
         <ul>
           <li data-prop="comments">I disagree.</li>
         </ul>
       </article>
       <article data-scope="posts">
         <p data-prop="body">JavaScript is dead.</p>
+        <a href="https://iamvery.com" data-prop="link">Iamvery</a>
         <ul>
           <li data-prop="comments">WAT</li>
           <li data-prop="comments">YAY</li>

--- a/test/ratchet/transformer_test.exs
+++ b/test/ratchet/transformer_test.exs
@@ -13,7 +13,7 @@ defmodule Ratchet.TransformerTest do
         "<%= for list <- List.wrap(data.list) do %>",
         {"ul", [{"data-scope", "list"}], [
           "<%= for name <- List.wrap(list.name) do %>",
-          {"li", [{"data-prop", "name"}], ["<%= Ratchet.Data.content(name) %>"]},
+          {"li", ["<%= Ratchet.Data.attributes(name, [{\"data-prop\", \"name\"}]) %>"], ["<%= Ratchet.Data.content(name) %>"]},
           "<% end %>",
         ]},
         "<% end %>",


### PR DESCRIPTION
This is an alternative to #14. Instead of having to state the attributes in the template, they are generated based on the data. This way a property is a property which may itself have content _and_ attributes.

Views can be transformed with attributes:

template

``` html
<div>
  <a data-prop="link"></a>
</div>
```

data

``` elixir
data = %{link: {"iamvery", href: "iamvery.com", rel: "nofollow"}}
```

rendered

``` html
<div>
  <a rel="nofollow" href="iamvery.com" data-prop="link">iamvery</a>
</div>
```
