### PR TITLE
Use phoenix sanitization when available

### DIFF
--- a/lib/ratchet/eex.ex
+++ b/lib/ratchet/eex.ex
@@ -25,8 +25,14 @@ defmodule Ratchet.EEx do
       iex> Ratchet.EEx.eex_attributes("lolwat", [])
       "<%= Ratchet.Data.attributes(lolwat, []) %>"
   """
-  def eex_attributes(property, attributes) do
-    "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
+  if Code.ensure_loaded?(Phoenix.HTML) do
+    def eex_attributes(property, attributes) do
+      "<%= Phoenix.HTML.raw Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
+    end
+  else
+    def eex_attributes(property, attributes) do
+      "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
+    end
   end
 
   @doc """


### PR DESCRIPTION
Phoenix uses a custom EEx engine to ensure that all values injected into
views are "safe" from XSS attacks. Since ratchet builds html attributes
dynamically, these values must be marked as safe for the correct view to
be rendered by Phoenix. However, it is desirable to keep the ratchet
library decoupled from Phoenix as it may be used in other contexts.

To be frank, this solution feels bad. Just because the Phoenix.HTML
module is loaded does not mean that it is being used in rendering the
template. Therefore, there is a chance that views rendered outside
Phoenix (but in its presence) will confusing be marked as "Phoenix
safe". For now, that's a risk we'll have to take... Would love to find a
better solution to this problem.
