### PR TITLE
<fix> flattens top level lists to comply with Flokis raw_html from as…

### DIFF
--- a/lib/ratchet/transformer.ex
+++ b/lib/ratchet/transformer.ex
@@ -8,7 +8,7 @@ defmodule Ratchet.Transformer do
 
   def transform([], _), do: []
   def transform([child|rest], scope) do
-    [transform(child, scope)|transform(rest, scope)]
+    [transform(child, scope)|transform(rest, scope)] |> List.flatten
   end
 
   def transform(text, _scope) when is_binary(text), do: text

--- a/test/ratchet/renderer_test.exs
+++ b/test/ratchet/renderer_test.exs
@@ -4,6 +4,8 @@ defmodule Ratchet.RendererTest do
   doctest Renderer
 
   @template """
+  <div>content</div>
+  <div data-scope="toplevel"></div>
   <section>
     <article data-scope="posts">
       <p data-prop="body"></p>
@@ -16,12 +18,14 @@ defmodule Ratchet.RendererTest do
   """
 
   test "render/2" do
-    data = %{posts: [
+    data = %{toplevel: "", posts: [
         %{body: "Thoughts and opinions.", link: {"Google", href: "https://google.com"}, comments: ["I disagree."]},
         %{body: "JavaScript is dead.", link: {"Iamvery", href: "https://iamvery.com"}, comments: ["WAT", "YAY"]},
       ]}
 
     rendered = """
+    <div>content</div>
+    <div data-scope="toplevel"></div>
     <section>
       <article data-scope="posts">
         <p data-prop="body">Thoughts and opinions.</p>


### PR DESCRIPTION
…t generation

This fixes the case where you have two top level things in your html (whether it be an element or content) and a data-*.
### Example

```
<div> content </div>
<div data-scope="toplevel"></div>
```

Previously this would wrap the scope in two lists causing the generated ast to not match any `Floki.raw_html` definitions.
