### PR TITLE
Revert "Use phoenix sanitization when available"

### DIFF
--- a/lib/ratchet/eex.ex
+++ b/lib/ratchet/eex.ex
@@ -25,14 +25,8 @@ defmodule Ratchet.EEx do
       iex> Ratchet.EEx.eex_attributes("lolwat", [])
       "<%= Ratchet.Data.attributes(lolwat, []) %>"
   """
-  if Code.ensure_loaded?(Phoenix.HTML) do
-    def eex_attributes(property, attributes) do
-      "<%= Phoenix.HTML.raw Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
-    end
-  else
-    def eex_attributes(property, attributes) do
-      "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
-    end
+  def eex_attributes(property, attributes) do
+    "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
   end
 
   @doc """


### PR DESCRIPTION
Reverts iamvery/ratchet#18

Unfortunately this didn't work with the Phoenix integration. It appeared to in my local tests, but CI tells a different story https://travis-ci.org/iamvery/phoenix_ratchet/builds/132558021. Since it's a decidedly terrible solution, I'm reverting and coming back to it...

---

My current line of thought is to just couple ratchet to phoenix for now to keep things moving. Then perhaps we can circle back and decouple 😕 
