### PR TITLE
Safe HTML

### DIFF
--- a/lib/ratchet/data.ex
+++ b/lib/ratchet/data.ex
@@ -28,10 +28,10 @@ defmodule Ratchet.Data do
   end
 
   defp build_attr({attribute, value}) do
-    ~s(#{safe attribute}="#{safe value}")
+    ~s(#{escape attribute}="#{escape value}")
   end
 
-  defp safe(value) do
+  defp escape(value) do
     value |> Phoenix.HTML.html_escape |> Phoenix.HTML.safe_to_string
   end
 end

--- a/lib/ratchet/data.ex
+++ b/lib/ratchet/data.ex
@@ -28,6 +28,10 @@ defmodule Ratchet.Data do
   end
 
   defp build_attr({attribute, value}) do
-    ~s(#{attribute}="#{value}")
+    ~s(#{safe attribute}="#{safe value}")
+  end
+
+  defp safe(value) do
+    value |> Phoenix.HTML.html_escape |> Phoenix.HTML.safe_to_string
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Ratchet.Mixfile do
   defp deps do
     [
       {:floki, "~> 0.8"}, # HTML parser
+      {:phoenix_html, "~> 2.5.1"}, # safe HTML
       {:ex_doc, "~> 0.11", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
 %{"ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "floki": {:hex, :floki, "0.8.1", "06aa75bf2d1e01cda7d2ad54f68614be653a11e76b474d8fcb1d838f8c1e0ad1", [:mix], [{:mochiweb_html, "~> 2.15", [hex: :mochiweb_html, optional: false]}]},
-  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []}}
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []},
+  "phoenix_html": {:hex, :phoenix_html, "2.5.1", "631053f9e345fecb5c87d9e0ccd807f7266d27e2ee4269817067af425fd81ba8", [:mix], [{:plug, "~> 0.13 or ~> 1.0", [hex: :plug, optional: false]}]},
+  "plug": {:hex, :plug, "1.1.4", "2eee0e85ad420db96e075b3191d3764d6fff61422b101dc5b02e9cce99cacfc7", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]}}

--- a/test/ratchet/data_test.exs
+++ b/test/ratchet/data_test.exs
@@ -2,4 +2,16 @@ defmodule Ratchet.DataTest do
   use ExUnit.Case, async: true
   alias Ratchet.Data
   doctest Data
+
+  test "attributes names are safe" do
+    attributes = Data.attributes(nil, [{~S{onclick="alert('HACKED!')" class}, ""}])
+
+    assert attributes == ~S{onclick=&quot;alert(&#39;HACKED!&#39;)&quot; class=""}
+  end
+
+  test "attributes values are safe" do
+    attributes = Data.attributes(nil, [{"class", ~S{" onclick="alert('HACKED!')}}])
+
+    assert attributes == ~S{class="&quot; onclick=&quot;alert(&#39;HACKED!&#39;)"}
+  end
 end


### PR DESCRIPTION
The HTML attributes are built dynamically, and therefore expose an opportunity for an XSS attack. Using the phoenix_html lib, we can sanitize markup just like Phoenix does to mitigate such an attack.
