### PR TITLE
Mark generated attributes as safe

### DIFF
--- a/lib/ratchet/data.ex
+++ b/lib/ratchet/data.ex
@@ -14,9 +14,9 @@ defmodule Ratchet.Data do
   Extract attributes from a data property
 
       iex> Data.attributes({"", href: "https://google.com", rel: "nofollow"}, [])
-      ~S(href="https://google.com" rel="nofollow")
+      {:safe, ~S(href="https://google.com" rel="nofollow")}
       iex> Data.attributes("lolwat", [{"data-prop", "joke"}])
-      ~S(data-prop="joke")
+      {:safe, ~S(data-prop="joke")}
   """
   def attributes({_content, data_attrs}, elem_attrs) do
     build_attrs(data_attrs ++ elem_attrs)
@@ -25,6 +25,7 @@ defmodule Ratchet.Data do
 
   defp build_attrs(attributes) do
     Enum.map_join(attributes, " ", &build_attr/1)
+    |> Phoenix.HTML.raw
   end
 
   defp build_attr({attribute, value}) do

--- a/lib/ratchet/renderer.ex
+++ b/lib/ratchet/renderer.ex
@@ -36,6 +36,7 @@ defmodule Ratchet.Renderer do
   end
 
   defp eval(template, data) do
-    EEx.eval_string(template, data: data)
+    EEx.eval_string(template, [data: data], engine: Phoenix.HTML.Engine)
+    |> Phoenix.HTML.safe_to_string
   end
 end

--- a/test/ratchet/data_test.exs
+++ b/test/ratchet/data_test.exs
@@ -6,12 +6,12 @@ defmodule Ratchet.DataTest do
   test "attributes names are safe" do
     attributes = Data.attributes(nil, [{~S{onclick="alert('HACKED!')" class}, ""}])
 
-    assert attributes == ~S{onclick=&quot;alert(&#39;HACKED!&#39;)&quot; class=""}
+    assert attributes == {:safe, ~S{onclick=&quot;alert(&#39;HACKED!&#39;)&quot; class=""}}
   end
 
   test "attributes values are safe" do
     attributes = Data.attributes(nil, [{"class", ~S{" onclick="alert('HACKED!')}}])
 
-    assert attributes == ~S{class="&quot; onclick=&quot;alert(&#39;HACKED!&#39;)"}
+    assert attributes == {:safe, ~S{class="&quot; onclick=&quot;alert(&#39;HACKED!&#39;)"}}
   end
 end


### PR DESCRIPTION
In order for ratchet to work with Phoenix, generated attributes must be
flagged as "raw". Otherwise they would be sanitized during rendering.
This has the unfortunately effect of coupling ratchet to phoenix... I
think we'll just be OK with this for now given that phoenix is probably
its only use case. Eventually we'll need to provide some sort of hook
that performs the special behavior in the presence of phoenix.
