### PR TITLE
Move current Data module to Template

### DIFF
--- a/lib/ratchet/eex.ex
+++ b/lib/ratchet/eex.ex
@@ -7,11 +7,11 @@ defmodule Ratchet.EEx do
   Build an EEx list comprehension from a scope and a property
 
       iex> Ratchet.EEx.eex_comprehension_open("foo", "bar")
-      "<%= for bar <- Ratchet.Data.property(foo, :bar) |> Ratchet.Data.prepare do %>"
+      "<%= for bar <- Ratchet.Template.property(foo, :bar) |> Ratchet.Template.prepare do %>"
   """
   def eex_comprehension_open(scope, property) do
     property = String.to_atom(property)
-    "<%= for #{property} <- Ratchet.Data.property(#{scope}, #{inspect property}) |> Ratchet.Data.prepare do %>"
+    "<%= for #{property} <- Ratchet.Template.property(#{scope}, #{inspect property}) |> Ratchet.Template.prepare do %>"
   end
 
   @doc """
@@ -19,8 +19,8 @@ defmodule Ratchet.EEx do
 
       iex> Ratchet.EEx.eex_content("lolwat", ["Content"])
       [
-        "<%= if Ratchet.Data.content?(lolwat) do %>",
-        "<%= Ratchet.Data.content(lolwat) %>",
+        "<%= if Ratchet.Template.content?(lolwat) do %>",
+        "<%= Ratchet.Template.content(lolwat) %>",
         "<% else %>",
         "Content",
         "<% end %>",
@@ -28,8 +28,8 @@ defmodule Ratchet.EEx do
   """
   def eex_content(property, default) do
     [
-      "<%= if Ratchet.Data.content?(#{property}) do %>",
-      "<%= Ratchet.Data.content(#{property}) %>",
+      "<%= if Ratchet.Template.content?(#{property}) do %>",
+      "<%= Ratchet.Template.content(#{property}) %>",
       "<% else %>",
       default,
       eex_close,
@@ -40,10 +40,10 @@ defmodule Ratchet.EEx do
   Build an EEx statement fetching attributes
 
       iex> Ratchet.EEx.eex_attributes("lolwat", [])
-      "<%= Ratchet.Data.attributes(lolwat, []) %>"
+      "<%= Ratchet.Template.attributes(lolwat, []) %>"
   """
   def eex_attributes(property, attributes) do
-    "<%= Ratchet.Data.attributes(#{property}, #{inspect attributes}) %>"
+    "<%= Ratchet.Template.attributes(#{property}, #{inspect attributes}) %>"
   end
 
   @doc """

--- a/lib/ratchet/template.ex
+++ b/lib/ratchet/template.ex
@@ -1,4 +1,4 @@
-defmodule Ratchet.Data do
+defmodule Ratchet.Template do
   @moduledoc """
   Handles Ratchet data during EEx rendering
   """
@@ -15,15 +15,15 @@ defmodule Ratchet.Data do
   This function provides a consistent interface for fetching a property from
   some body of data.
 
-      iex> Data.property(%{}, :foo)
+      iex> Template.property(%{}, :foo)
       nil
-      iex> Data.property(%{foo: "bar"}, :foo)
+      iex> Template.property(%{foo: "bar"}, :foo)
       "bar"
-      iex> Data.property({%{foo: "bar"}, []}, :foo)
+      iex> Template.property({%{foo: "bar"}, []}, :foo)
       "bar"
-      iex> Data.property({"Content", []}, :foo)
+      iex> Template.property({"Content", []}, :foo)
       nil
-      iex> Data.property([attr: "value"], :foo)
+      iex> Template.property([attr: "value"], :foo)
       nil
   """
   def property({map, _attributes}, property) when is_map(map), do: map[property]
@@ -37,17 +37,17 @@ defmodule Ratchet.Data do
   rendering multiple elements. This function supports that requirement by
   ensuring elements are wrapped in a list.
 
-      iex> Data.prepare("data")
+      iex> Template.prepare("data")
       ["data"]
-      iex> Data.prepare(["one", "two"])
+      iex> Template.prepare(["one", "two"])
       ["one", "two"]
-      iex> Data.prepare([href: "/"])
+      iex> Template.prepare([href: "/"])
       [[href: "/"]]
-      iex> Data.prepare([{"foo", href: "/"}])
+      iex> Template.prepare([{"foo", href: "/"}])
       [{"foo", href: "/"}]
-      iex> Data.prepare({"foo", class: "btn"})
+      iex> Template.prepare({"foo", class: "btn"})
       [{"foo", class: "btn"}]
-      iex> Data.prepare(nil)
+      iex> Template.prepare(nil)
       [nil]
   """
   def prepare(nil), do: [nil]
@@ -57,15 +57,15 @@ defmodule Ratchet.Data do
   @doc """
   Determines if the given data provides plain text content
 
-      iex> Data.content?("text")
+      iex> Template.content?("text")
       true
-      iex> Data.content?({"text", href: "/foo/bar"})
+      iex> Template.content?({"text", href: "/foo/bar"})
       true
-      iex> Data.content?([href: "/"])
+      iex> Template.content?([href: "/"])
       false
-      iex> Data.content?(%{foo: "bar"})
+      iex> Template.content?(%{foo: "bar"})
       false
-      iex> Data.content?({%{foo: "bar"}, action: "/baz"})
+      iex> Template.content?({%{foo: "bar"}, action: "/baz"})
       false
   """
   def content?({text, _attributes}) when is_binary(text), do: true
@@ -75,9 +75,9 @@ defmodule Ratchet.Data do
   @doc """
   Extract content from a data property
 
-      iex> Data.content("text")
+      iex> Template.content("text")
       "text"
-      iex> Data.content({"text", []})
+      iex> Template.content({"text", []})
       "text"
   """
   def content({text, _attributes}) when is_binary(text), do: text
@@ -86,13 +86,13 @@ defmodule Ratchet.Data do
   @doc """
   Extract attributes from a data property
 
-      iex> Data.attributes({"", href: "https://google.com", rel: "nofollow"}, [])
+      iex> Template.attributes({"", href: "https://google.com", rel: "nofollow"}, [])
       {:safe, ~S(href="https://google.com" rel="nofollow")}
-      iex> Data.attributes([href: "/"], [{"data-prop", "link"}])
+      iex> Template.attributes([href: "/"], [{"data-prop", "link"}])
       {:safe, ~S(href="/" data-prop="link")}
-      iex> Data.attributes([{"foo", href: "/"}], [{"data-prop", "link"}])
+      iex> Template.attributes([{"foo", href: "/"}], [{"data-prop", "link"}])
       {:safe, ~S(data-prop="link")}
-      iex> Data.attributes("lolwat", [{"data-prop", "joke"}])
+      iex> Template.attributes("lolwat", [{"data-prop", "joke"}])
       {:safe, ~S(data-prop="joke")}
   """
   def attributes({_content, data_attrs}, elem_attrs) do

--- a/test/ratchet/template_test.exs
+++ b/test/ratchet/template_test.exs
@@ -1,16 +1,16 @@
-defmodule Ratchet.DataTest do
+defmodule Ratchet.TemplateTest do
   use ExUnit.Case, async: true
-  alias Ratchet.Data
-  doctest Data
+  alias Ratchet.Template
+  doctest Template
 
   test "attributes names are safe" do
-    attributes = Data.attributes(nil, [{~S{onclick="alert('HACKED!')" class}, ""}])
+    attributes = Template.attributes(nil, [{~S{onclick="alert('HACKED!')" class}, ""}])
 
     assert attributes == {:safe, ~S{onclick=&quot;alert(&#39;HACKED!&#39;)&quot; class=""}}
   end
 
   test "attributes values are safe" do
-    attributes = Data.attributes(nil, [{"class", ~S{" onclick="alert('HACKED!')}}])
+    attributes = Template.attributes(nil, [{"class", ~S{" onclick="alert('HACKED!')}}])
 
     assert attributes == {:safe, ~S{class="&quot; onclick=&quot;alert(&#39;HACKED!&#39;)"}}
   end

--- a/test/ratchet/transformer_test.exs
+++ b/test/ratchet/transformer_test.exs
@@ -8,10 +8,10 @@ defmodule Ratchet.TransformerTest do
     ]}
 
   @eex_list_ast {"ul", [], [
-        "<%= for name <- Ratchet.Data.property(data, :name) |> Ratchet.Data.prepare do %>",
-        {"li", ["<%= Ratchet.Data.attributes(name, [{\"data-prop\", \"name\"}]) %>"], [
-          "<%= if Ratchet.Data.content?(name) do %>",
-          "<%= Ratchet.Data.content(name) %>",
+        "<%= for name <- Ratchet.Template.property(data, :name) |> Ratchet.Template.prepare do %>",
+        {"li", ["<%= Ratchet.Template.attributes(name, [{\"data-prop\", \"name\"}]) %>"], [
+          "<%= if Ratchet.Template.content?(name) do %>",
+          "<%= Ratchet.Template.content(name) %>",
           "<% else %>",
           "<% end %>",
         ]},
@@ -37,10 +37,10 @@ defmodule Ratchet.TransformerTest do
 
     assert result == [
       {"h2", [], []},
-      "<%= for foo <- Ratchet.Data.property(data, :foo) |> Ratchet.Data.prepare do %>",
-      {"div", ["<%= Ratchet.Data.attributes(foo, [{\"data-prop\", \"foo\"}]) %>"], [
-        "<%= if Ratchet.Data.content?(foo) do %>",
-        "<%= Ratchet.Data.content(foo) %>",
+      "<%= for foo <- Ratchet.Template.property(data, :foo) |> Ratchet.Template.prepare do %>",
+      {"div", ["<%= Ratchet.Template.attributes(foo, [{\"data-prop\", \"foo\"}]) %>"], [
+        "<%= if Ratchet.Template.content?(foo) do %>",
+        "<%= Ratchet.Template.content(foo) %>",
         "<% else %>",
         "<% end %>",
       ]},


### PR DESCRIPTION
Want to free up the Ratchet.Data module for other uses. Template is used internally by the compiled EEx when processing Ratchet templates..
