### PR TITLE
Update implementation to support struct data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.2.2
+  - 1.3.2
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Move things under Ratchet.Data to Ratchet.Template (https://github.com/iamvery/ratchet/pull/49)
+- Support struct data (https://github.com/iamvery/ratchet/pull/52)
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.3...HEAD

--- a/lib/ratchet/template.ex
+++ b/lib/ratchet/template.ex
@@ -26,8 +26,8 @@ defmodule Ratchet.Template do
       iex> Template.property([attr: "value"], :foo)
       nil
   """
-  def property({map, _attributes}, property) when is_map(map), do: map[property]
-  def property(map, property) when is_map(map), do: map[property]
+  def property({map, _attributes}, property) when is_map(map), do: Map.get(map, property)
+  def property(map, property) when is_map(map), do: Map.get(map, property)
   def property(_other, _property), do: nil
 
   @doc """

--- a/test/ratchet/template_test.exs
+++ b/test/ratchet/template_test.exs
@@ -3,6 +3,16 @@ defmodule Ratchet.TemplateTest do
   alias Ratchet.Template
   doctest Template
 
+  describe "property/2" do
+    defmodule Foo do
+      defstruct bar: nil
+    end
+
+    test "properties may be fetched from structs" do
+      assert Template.property(%Foo{bar: "baz"}, :bar) == "baz"
+    end
+  end
+
   test "attributes names are safe" do
     attributes = Template.attributes(nil, [{~S{onclick="alert('HACKED!')" class}, ""}])
 


### PR DESCRIPTION
Elixir structs do not implement the Access protocol which is used by
[]/1. However, structs are compatible with Map.\* as they are so called
"bare" maps.
