### PR TITLE
Support content marked as "safe"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Move things under Ratchet.Data to Ratchet.Template (https://github.com/iamvery/ratchet/pull/49)
 - Support struct data (https://github.com/iamvery/ratchet/pull/52)
 - Support non-string content (https://github.com/iamvery/ratchet/pull/47)
+- Support Phoenix "safe" content in transforms (https://github.com/iamvery/ratchet/pull/54)
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.3...HEAD

--- a/lib/ratchet/template.ex
+++ b/lib/ratchet/template.ex
@@ -63,6 +63,8 @@ defmodule Ratchet.Template do
       true
       iex> Template.content?(123)
       true
+      iex> Template.content?({:safe, "<p>lolwat</p>"})
+      true
       iex> Template.content?([href: "/"])
       false
       iex> Template.content?(%{foo: "bar"})
@@ -87,7 +89,12 @@ defmodule Ratchet.Template do
       123
       iex> Template.content({"text", []})
       "text"
+      iex> Template.content({:safe, "<p>lolwat</p>"})
+      {:safe, "<p>lolwat</p>"}
+      iex> Template.content({{:safe, "<p>lolwat</p>"}, []})
+      {:safe, "<p>lolwat</p>"}
   """
+  def content({:safe, _} = content), do: content
   def content({content, _attrs}), do: content
   def content(content), do: content
 
@@ -102,7 +109,10 @@ defmodule Ratchet.Template do
       {:safe, ~S(data-prop="link")}
       iex> Template.attributes("lolwat", [{"data-prop", "joke"}])
       {:safe, ~S(data-prop="joke")}
+      iex> Template.attributes({:safe, "lolwat"}, [{"lol", "wat"}])
+      {:safe, ~S(lol="wat")}
   """
+  def attributes({:safe, _content}, elem_attrs), do: build_attrs(elem_attrs)
   def attributes({_content, data_attrs}, elem_attrs) do
     build_attrs(data_attrs ++ elem_attrs)
   end


### PR DESCRIPTION
This is a Phoenix idiom. In Phoenix content may be marked as safe by
using Phoenix.HTML.raw/1. In order to bind raw content with Ratchet, the
transforms must support content in this form. Hopefully we can
decoupling these details of Ratchet from Phoenix at some point.

[closes #53]
