### PR TITLE
Log a warning when property is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added changelog to project
 - Added Ratchet.Data module for data building (https://github.com/iamvery/ratchet/pull/46)
+- Missing property emits a warning (https://github.com/iamvery/ratchet/pull/58)
 
 ### Changed
 - Move things under Ratchet.Data to Ratchet.Template (https://github.com/iamvery/ratchet/pull/49)

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,10 +21,4 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :logger, level: :error

--- a/lib/ratchet/template.ex
+++ b/lib/ratchet/template.ex
@@ -3,6 +3,8 @@ defmodule Ratchet.Template do
   Handles Ratchet data during EEx rendering
   """
 
+  require Logger
+
   @doc """
   Get the specified property from the given data
 
@@ -27,8 +29,16 @@ defmodule Ratchet.Template do
       nil
   """
   def property({data, _attributes}, property), do: property(data, property)
-  def property(map, property) when is_map(map), do: Map.get(map, property)
-  def property(_other, _property), do: nil
+  def property(map, property) when is_map(map) do
+    Map.get(map, property) |> log(property, map)
+  end
+  def property(data, property), do: log(nil, property, data)
+
+  defp log(nil, property, data) do
+    Logger.warn "Property #{inspect property} not available in data #{inspect data}"
+    nil
+  end
+  defp log(value, _property, _data), do: value
 
   @doc """
   Prepares data for list comprehension

--- a/lib/ratchet/template.ex
+++ b/lib/ratchet/template.ex
@@ -26,7 +26,7 @@ defmodule Ratchet.Template do
       iex> Template.property([attr: "value"], :foo)
       nil
   """
-  def property({map, _attributes}, property) when is_map(map), do: Map.get(map, property)
+  def property({data, _attributes}, property), do: property(data, property)
   def property(map, property) when is_map(map), do: Map.get(map, property)
   def property(_other, _property), do: nil
 


### PR DESCRIPTION
In practice, when a property is not found, it indicates that the user has added a data-prop to their template, but not provided data for rendering. This means one of three things:
1. They are prototyping their app and haven't wired up data yet. So the warning is innocent enough and can be ignored.
2. They have forgotten to include data. In that case, the warning serves as a reminder that they need to wire things up.
3. There is a typo in their properties. Either on the template side or the data side there is a typo. The warning serves as an indicator to spark their mind into realizing this.

[closes #57]
